### PR TITLE
added UTF-8 encoding

### DIFF
--- a/starterbot.py
+++ b/starterbot.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 import os
 import time
 from slackclient import SlackClient


### PR DESCRIPTION
I added
 # -*- coding: utf-8 -*- 

Slack recently allowed unicode characters in, and I had a problem with the above code (line 40):

if output and 'text' in output and AT_BOT in output['text']

the : AT_BOT in output['text'] 
was always false as AT_BOT was a string as output['text'] was unicode. 

With that line at the head of the file fixed it for me. I believe it should not pose problem. 


Loved your tutorial, really helped me. 
Best,
R.